### PR TITLE
added ctrl-d handling in posix

### DIFF
--- a/pytimedinput/pytimedinput.py
+++ b/pytimedinput/pytimedinput.py
@@ -153,6 +153,7 @@ def __timedInput(prompt: str = "", timeout: int = 5, resetOnInput: bool = True, 
                         print("\x1b[1D\x1b[0K", end='', flush=True)
                 if(resetOnInput and timeout > -1):
                     timeStart = time.time()
+            time.sleep(0.01)
         print("")
         __setStdoutSettings(__savedConsoleSettings)
         return userInput, timedOut
@@ -187,3 +188,10 @@ def __enableStdoutAnsiEscape():
     else:
         # Should be enabled by default under Linux (and OSX?), just set cbreak-mode
         tty.setcbreak(sys.stdin.fileno(), termios.TCSADRAIN)
+
+
+def main():
+    timedInput("Enter: ", timeout=5)
+
+if __name__ == '__main__':
+    main()

--- a/pytimedinput/pytimedinput.py
+++ b/pytimedinput/pytimedinput.py
@@ -125,6 +125,9 @@ def __timedInput(prompt: str = "", timeout: int = 5, resetOnInput: bool = True, 
                 break
             if(checkStdin()):
                 inputCharacter = readStdin()
+                if inputCharacter == '\x04':  # ctrl-d pressed --> raise EOFError
+                    __setStdoutSettings(__savedConsoleSettings)
+                    raise EOFError
                 if(inputCharacter in endCharacters):
                     break
                 if(inputCharacter != '\b' and inputCharacter != '\x7f'):


### PR DESCRIPTION
Hi,
I added a ctrl-d handling in the __timedInput function.

I expect that the timedInput will raise an EOFError when ctrl-d is pressed. Do you think this makes sense?

Best regards, Jens